### PR TITLE
Add basic linear regression model using scikit-learn

### DIFF
--- a/linearregression/model.py
+++ b/linearregression/model.py
@@ -1,0 +1,29 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns
+from sklearn.datasets import load_diabetes
+from sklearn.linear_model import LinearRegression
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import r2_score
+
+# Load data
+diabetes = load_diabetes()
+X = pd.DataFrame(diabetes.data, columns=diabetes.feature_names)
+y = pd.Series(diabetes.target, name='target')
+
+# Combine into one DataFrame (optional)
+df = pd.concat([X, y], axis=1)
+print(df.head())
+
+# Split into train and test sets
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+
+# Train model
+lr = LinearRegression()
+lr.fit(X_train, y_train)
+
+# Predict
+y_pred = lr.predict(X_test)
+
+# Evaluate
+print("R2 Score:", r2_score(y_test, y_pred))


### PR DESCRIPTION
What I did:

Utilized scikit-learn’s built-in load_diabetes() dataset.

Split the data into training and testing sets using train_test_split.

Trained a Linear Regression model using LinearRegression() from sklearn.linear_model.

Evaluated model performance using R² score from sklearn.metrics.

Model Objective:
To predict diabetes progression based on 10 baseline variables using a simple linear regression model.

